### PR TITLE
Integrate Travis for first step of build process. Ref #145

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+# Link repository with Travis CI
+# https://travis-ci.org/
+
+# Whitelist gh-pages branch
+branches:
+  only:
+    - integratetravis
+
+# Set the language
+language: bash
+
+# Set the environment path to include Pandoc binaries
+env:
+  global:
+    - PATH=$TRAVIS_BUILD_DIR/usr/bin/:$PATH
+
+before_install:
+  # Fetch pandoc and pandoc-citeproc binaries
+  - wget https://github.com/jgm/pandoc/releases/download/1.15.0.5/pandoc-1.15.0.5-1-amd64.deb && ar p pandoc-1.15.0.5-1-amd64.deb data.tar.gz | tar zx
+  # Install TeX Live
+  - sudo add-apt-repository -y ppa:texlive-backports/ppa
+  - sudo apt-get update -qq
+  - sudo apt-get install texlive-xetex texlive-latex-recommended texlive-latex-extra
+  - sudo apt-get install texlive-fonts-recommended texlive-fonts-extra
+  - sudo apt-get install texlive-science
+  # Install fonts
+  # - sudo apt-get install lmodern
+
+# Attempt to create a PDF
+script:
+  - cd document && make pdf

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,6 @@ before_install:
   # Install fonts
   # - sudo apt-get install lmodern
 
-# Attempt to create a PDF
+# Attempt to create manuscript.tex
 script:
-  - cd document && make pdf
+  - cd document && manuscript.tex

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ before_install:
 
 # Attempt to create manuscript.tex
 script:
-  - cd document && manuscript.tex
+  - cd document && make manuscript.tex

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ten Simple Rules for taking advantage of GitHub [![Build Status](https://travis-ci.org/tompollard/github-paper.svg?branch=master)](https://travis-ci.org/tompollard/github-paper)
+# Ten Simple Rules for taking advantage of GitHub [![Build Status](https://travis-ci.org/ypriverol/github-paper.svg?branch=master)](https://travis-ci.org/ypriverol/github-paper)
 
 ## Description 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ten Simple Rules for taking advantage of GitHub
+# Ten Simple Rules for taking advantage of GitHub [![Build Status](https://travis-ci.org/tompollard/github-paper.svg?branch=master)](https://travis-ci.org/tompollard/github-paper)
 
 ## Description 
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 ## Description 
 
-This repository contains the manuscript entitle:
+This repository contains the manuscript entitled:
 [**Ten Simple Rules for taking advantage of GitHub (in bioinformatics)**](https://github.com/ypriverol/github-paper/blob/master/document/manuscript.md). Our
 aim here is to describe how the bioinformatics community can use
-GitHub features and tools on a daily basics.
+GitHub features and tools on a daily basis.
 
 ## Commenting and contributing 
 
@@ -18,7 +18,7 @@ requests.
 Feel free to browse through existing/past issues and if one seems
 related, comment on it. If no existing issue seems appropriate, a new
 issue can be opened to discuss the suggestion. In particular, we would
-appreciate to discuss more substantial changes (for example suggestion
+appreciate discussing more substantial changes (for example suggestion
 of new rules) in a dedicated issue before sending a pull request.
 
 If you are new to Git, read the
@@ -66,6 +66,6 @@ make clean
 ## Disclaimer
 
 The authors have no affiliation with [GitHub](https://github.com/),
-nor any commercial entity mentioned in this articel. The views
-described here reflect our owns without any input from any third party
+nor any commercial entity mentioned in this article. The views
+described here reflect our own views without input from any third party
 organisation.


### PR DESCRIPTION
This pull request adds the .travis.yml file for integrating the repository with Travis CI (https://travis-ci.org). After merging the pull request, please could @ypriverol or another repo owner:
1. go to https://travis-ci.org/ and sign up (if not already done so)
2. navigate to the profile page (e.g. https://travis-ci.org/profile/ypriverol) and select this repo from the list (click the 'sync account' button if it doesn't appear).
3. trigger a new build by pushing a change to the repo.

A couple of points to note:
- I have updated the README to display a build status badge, but the link will be broken until the Travis account has been created.
- We are only testing the "make manuscript.tex" step at present, because the later stages of the build process are not automated ("include the text from manuscript.tex" and "Comment the figure inclusion line.")
